### PR TITLE
init cursor when the log file is rotated

### DIFF
--- a/lib/ginx.js
+++ b/lib/ginx.js
@@ -151,6 +151,7 @@ Ginx.prototype.parseFile = function (file, rowCallback, fileCallback, dirCallbac
         if (cursor > size) {
             console.log("[GINX-DEBUG] File is rotated so cursor is initialized.");
             cursor = 0;
+			MEM_STORAGE.cursors[strgKey] = 0;
         }
 
         var stream = fs.createReadStream(file, {'start': cursor});

--- a/lib/ginx.js
+++ b/lib/ginx.js
@@ -145,8 +145,15 @@ Ginx.prototype.parseFile = function (file, rowCallback, fileCallback, dirCallbac
             return;
         }
         var overflow = "",
-            size = stats.size,
-            stream = fs.createReadStream(file, {'start': cursor});
+            size = stats.size;
+
+        // when access.log is rotated
+        if (cursor > size) {
+            console.log("[GINX-DEBUG] File is rotated so cursor is initialized.");
+            cursor = 0;
+        }
+
+        var stream = fs.createReadStream(file, {'start': cursor});
         that.rstreams[file] = stream;
         console.log("[GINX-DEBUG] File Size: " + size + " bytes -- File Cursor stored at position: " + cursor);
         if (size - 1 > cursor || size === -1) {


### PR DESCRIPTION
I let the cursor be initialized when the log file of nginx is rotated by [logrotate](http://www.linuxcommand.org/man_pages/logrotate8.html).